### PR TITLE
feat: generation of option docs

### DIFF
--- a/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
+++ b/src/Component/OpenApi3/Generator/Parameter/NonBodyParameterGenerator.php
@@ -153,7 +153,12 @@ class NonBodyParameterGenerator extends ParameterGenerator
             $type = implode('|', $this->convertParameterType($parameter->getSchema()));
         }
 
-        return sprintf(' *     @var %s $%s %s', $type, $parameter->getName(), $parameter->getDescription() ?: '');
+        return sprintf(
+            ' *      \'%s\': %s,%s',
+            $parameter->getName(),
+            $type,
+            $parameter->getDescription() ? ' ' . $parameter->getDescription() : ''
+        );
     }
 
     /**


### PR DESCRIPTION
Less ambiguity.

Example before and after:

```php

     * @param array $queryParameters {
     *
     * @var string $organization[id] The organization to find disks for. All 'organization[]' params are mutually exclusive, only one can be provided.
     * @var string $organization[sub_domain] The organization to find disks for. All 'organization[]' params are mutually exclusive, only one can be provided.
     * @var string $annotations[key] An array of annotations to filter by. All 'annotations[]' params are mutually exclusive, only one can be provided.
     * @var string $annotations[value] An array of annotations to filter by. All 'annotations[]' params are mutually exclusive, only one can be provided.
     * @var int    $page
     * @var int    $per_page
     *             }
     *
```

```php

     * @param array  $queryParameters {
     *     'organization[id]': string, The organization to find disks for. All 'organization[]' params are mutually exclusive, only one can be provided.
     *     'organization[sub_domain]': string, The organization to find disks for. All 'organization[]' params are mutually exclusive, only one can be provided.
     *     'annotations[key]': string, An array of annotations to filter by. All 'annotations[]' params are mutually exclusive, only one can be provided.
     *     'annotations[value]': string, An array of annotations to filter by. All 'annotations[]' params are mutually exclusive, only one can be provided.
     *     'page': int,
     *     'per_page': int,
     * }
```